### PR TITLE
Changes to the way Mapper::Save() works

### DIFF
--- a/Exception/SaveException.php
+++ b/Exception/SaveException.php
@@ -1,0 +1,57 @@
+<?php
+namespace Ddeboer\Salesforce\MapperBundle\Exception;
+
+/**
+ * SaveException is thrown if saving models fails
+ */
+class SaveException extends \Exception
+{
+    /**
+     * Models that were saved succesfully
+     * @param array
+     */
+    protected $okModels = array();
+    
+    /**
+     * Models that had errors while saving
+     * @param array
+     */
+    protected $errorModels = array();
+    
+    /**
+     * getOkModels
+     * @return array
+     */
+    public function getOkModels()
+    {
+        return $this->okModels;
+    }
+    
+    /**
+     * setOkModels
+     * @param array $okModels
+     */
+    public function setOkModels(array $okModels)
+    {
+        $this->okModels = $okModels;
+    }
+    
+    /**
+     * getErrorModels
+     * @return array
+     */
+    public function getErrorModels()
+    {
+        return $this->errorModels;
+    }
+    
+    /**
+     * setOkModels
+     * @param array $errorModels
+     */
+    public function setErrorModels(array $errorModels)
+    {
+        $this->errorModels = $errorModels;
+    }
+}
+?>

--- a/Model/AbstractModel.php
+++ b/Model/AbstractModel.php
@@ -52,6 +52,16 @@ abstract class AbstractModel
      * @Salesforce\Field(name="SystemModstamp")
      */
     protected $systemModstamp;
+    
+    /**
+     * @var bool
+     */
+    protected $success;
+
+    /**
+     * @var array
+     */
+    protected $errors = array();
 
     /**
      * @return string
@@ -107,5 +117,21 @@ abstract class AbstractModel
     public function getSystemModstamp()
     {
         return $this->systemModstamp;
+    }
+    
+    /**
+     * @return bool
+     */
+    public function getSuccess()
+    {
+        return $this->success;
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,6 +12,8 @@
             <call method="setEventDispatcher">
                 <argument type="service" id="event_dispatcher" />
             </call>
+            <call method="disableClientResultCheck">
+            </call>
         </service>
 
         <service id="ddeboer_salesforce_mapper.bulk_saver" class="Ddeboer\Salesforce\MapperBundle\MappedBulkSaver">


### PR DESCRIPTION
I've made some changes to how saving works in mapper bundle. The reason for this change is to better handle cases where user is saving multiple models at once and Salesforce fails to save one or more of the models.

The changes:
- AbstractModel has two new properties success and errors, which are the values returned by Salesforce for each saved object.
- Client has a new property resultCheckDisabled which determines whether checkResult is called in doCall.
- Mapper has a new method disableClientResultCheck() whichs disables client's result check using the new property. This method is added to services.xml so that the check is automatically disabled.
- Mapper has a new exception SaveException, which extends \Extension and it contains properties okModels and errorModels and getters and setters for both. The idea is that when SaveException is thrown the okModels and errorModels are populated by the models which were saved succesfully and with those which had problems while saving.
- Mapper has a new method checkResult which loops through the saved models and if one of the models has success=false then it throws a SaveException.
- In Mapper::save() the values of models' success and errors properties are setted the same way as id is setted after saving a new model. Success and errors values are setted in both update and create cases.
- Instead of the client bundle throwing an exception if saving one of the given models fails, the results are checked in Mapper::save() by calling checkResult() which throws SaveException if one of the models has success=false.
- The user can catch the SaveException and then get the okModels and errorModels to better handle cases when something goes wrong in bulk save.
