### PR TITLE
A new pull request based on your comments about the previous one

### DIFF
--- a/Exception/Error.php
+++ b/Exception/Error.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Ddeboer\Salesforce\MapperBundle\Exception;
+
+class Error
+{
+    /**
+     * An array of Ddeboer\Salesforce\ClientBundle\Response\Error objects
+     * 
+     * @var array
+     */
+    public $errors;
+    
+    /**
+     * A mapper model
+     * 
+     * @var mixed
+     */
+    public $model;
+    
+    /**
+     * getErrors
+     * 
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+    
+    /**
+     * setErrors
+     * 
+     * @param array $errors
+     */
+    public function setErrors(array $errors)
+    {
+        return $this->errors = $errors;
+    }
+    
+    /**
+     * getModel
+     * 
+     * @return mixed
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+    
+    /**
+     * setModel
+     * 
+     * @param mixed $model
+     */
+    public function setModel($model)
+    {
+        $this->model = $model;
+    }
+}

--- a/Exception/SaveException.php
+++ b/Exception/SaveException.php
@@ -1,0 +1,57 @@
+<?php
+namespace Ddeboer\Salesforce\MapperBundle\Exception;
+
+/**
+ * SaveException is thrown if saving models fails
+ */
+class SaveException extends \Exception
+{
+    /**
+     * Models that were saved succesfully
+     * @param array
+     */
+    protected $okModels = array();
+    
+    /**
+     * Error objects containing the failed model and errors
+     * @param array
+     */
+    protected $errors = array();
+    
+    /**
+     * getOkModels
+     * @return array
+     */
+    public function getOkModels()
+    {
+        return $this->okModels;
+    }
+    
+    /**
+     * setOkModels
+     * @param array $okModels
+     */
+    public function setOkModels(array $okModels)
+    {
+        $this->okModels = $okModels;
+    }
+    
+    /**
+     * getErrors
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+    
+    /**
+     * setErrors
+     * @param array $errors
+     */
+    public function setErrors(array $errors)
+    {
+        $this->errors = $errors;
+    }
+}
+?>

--- a/Mapper.php
+++ b/Mapper.php
@@ -331,7 +331,7 @@ class Mapper
         }
         if (count($errors) > 0) 
         {
-            $saveException = new SaveException();
+            $saveException = new SaveException($errors[0]->errors[0]->message);
             $saveException->setOkModels($okModels);
             $saveException->setErrors($errors);
             throw $saveException;

--- a/Mapper.php
+++ b/Mapper.php
@@ -11,6 +11,9 @@ use Ddeboer\Salesforce\MapperBundle\Query\Builder;
 use Ddeboer\Salesforce\MapperBundle\Event\BeforeSaveEvent;
 use Doctrine\Common\Cache\Cache;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Ddeboer\Salesforce\MapperBundle\Exception\SaveException;
+use Ddeboer\Salesforce\MapperBundle\Exception\Error;
+use Ddeboer\Salesforce\ClientBundle\Exception\SaveException as ClientSaveException;
 
 /**
  * This mapper makes interaction with the Salesforce API using full objects
@@ -245,12 +248,14 @@ class Mapper
         $objectsToBeCreated = array();
         $objectsToBeUpdated = array();
         $modelsWithoutId = array();
+        $modelsToBeUpdated = array();
 
         foreach ($models as $model) {
             $object = $this->annotationReader->getSalesforceObject($model);
             $sObject = $this->mapToSalesforceObject($model);
             if (isset($sObject->Id) && null !== $sObject->Id) {
                 $objectsToBeUpdated[$object->name][] = $sObject;
+                $modelsToBeUpdated[$object->name][] = $model;
             } else {
                 $objectsToBeCreated[$object->name][] = $sObject;
                 $modelsWithoutId[$object->name][] = $model;
@@ -258,6 +263,7 @@ class Mapper
         }
 
         $results = array();
+        $checkModels = array();
         foreach ($objectsToBeCreated as $objectName => $sObjects) {
             $reflClass = new \ReflectionClass(current(
                 $modelsWithoutId[$objectName]
@@ -265,21 +271,72 @@ class Mapper
             $reflProperty = $reflClass->getProperty('id');
             $reflProperty->setAccessible(true);
 
-            $saveResults = $this->client->create($sObjects, $objectName);
+            try
+            {
+                $saveResults = $this->client->create($sObjects, $objectName);
+            } catch( ClientSaveException $e )
+            {
+                $saveResults = $e->getResults();
+            }
             for ($i = 0; $i < count($saveResults); $i++) {
                 $newId = $saveResults[$i]->id;
                 $model = $modelsWithoutId[$objectName][$i];                
                 $reflProperty->setValue($model, $newId);
             }
             
-            $results[] = $saveResults;
+            $checkModels = array_merge($checkModels, $modelsWithoutId[$objectName]);
+            $results = array_merge($results, $saveResults);
         }
 
         foreach ($objectsToBeUpdated as $objectName => $sObjects) {
-            $results[] = $this->client->update($sObjects, $objectName);
+            try
+            {
+                $updateResults = $this->client->update($sObjects, $objectName);
+            } catch( ClientSaveException $e )
+            {
+                $updateResults = $e->getResults();
+            }
+            $checkModels = array_merge($checkModels, $modelsToBeUpdated[$objectName]);
+            $results = array_merge($results, $updateResults);
         }
 
+        $this->checkResult($results,$checkModels);
+        
         return $results;
+    }
+    
+    /**
+     * Checks client results and throws SaveException if errors are found
+     * 
+     * @param array $results
+     * @param array $models
+     * @return bool
+     * @throws Ddeboer\Salesforce\MapperBundle\Exception\SaveException
+     */
+    private function checkResult(array $results, array $models)
+    {
+        $okModels = array();
+        $errors = array();
+        foreach($results as $key => $result)
+        {
+            if ($result->success)
+                $okModels[] = $models[$key];
+            else
+            {
+                $error = new Error();
+                $error->model = $models[$key];
+                $error->errors = $result->errors;
+                $errors[] = $error;
+            }
+        }
+        if (count($errors) > 0) 
+        {
+            $saveException = new SaveException();
+            $saveException->setOkModels($okModels);
+            $saveException->setErrors($errors);
+            throw $saveException;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
I modified SaveException so that it contains two properties: okModels and errors. OkModels is an array of successfully saved models and errors is an array containing instances of a new class Error. This class contains two properties model and errors. Model is the model which failed to save and errors is an array of errors returned by the Client related to that model.

I added SaveException class to the Client and modified Client::checkResult so that it throws a SaveException which contains the results of the Salesforce request.

Mapper::save catches the SaveExceptions thrown by the client and gets the results from the exception. Mapper::checkResult loops through these results and throws it's own SaveException if needed and inserts the model and errors to the Exception.
