### PR TITLE
Added support for using an array as a value in the findBy criteria.

### DIFF
--- a/Mapper.php
+++ b/Mapper.php
@@ -551,11 +551,23 @@ class Mapper
             if (!$field) {
                 throw new \InvalidArgumentException('Invalid field ' . $name);
             }
+            
+            if (is_array($value)) {
+                $quotedValueList = array();
+                
+                foreach ($value as $v) {
+                    $quotedValueList[] = $this->getQuotedWhereValue($field, $v, $objectDescription);
+                }
+                
+                $quotedValue = '(' . implode(',', $quotedValueList) . ')';
+            } else {
+                $quotedValue = $this->getQuotedWhereValue($field, $value, $objectDescription);
+            }
 
             $whereParts[] = sprintf('%s %s %s',
                 $field->name,
                 $operator,
-                $this->getQuotedWhereValue($field, $value, $objectDescription)
+                $quotedValue
             );
         }
 

--- a/Tests/MapperTest.php
+++ b/Tests/MapperTest.php
@@ -178,6 +178,32 @@ class MapperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($mapper->find(new Mock\AccountMock(), 1));
     }
+    
+    public function testBuildQueryWhereValueIsArray()
+    {
+        $queryResult = new Mock\QueryResultMock(2, true, array(
+            (object) array(
+                'Id' => '0010000000xxxx1',
+                'Name' => 'Test Account 1'
+            ),
+            (object) array(
+                'Id' => '0010000000xxxx2',
+                'Name' => 'Test Account 2'
+            )
+        ));
+        
+        $client = $this->getClient();
+        $client->expects($this->once())
+            ->method('query')
+            ->with("select Id,Name from Account where Id in ('0010000000xxxx1','0010000000xxxx2')")
+            ->will($this->returnValue(new RecordIterator($client, $queryResult)));
+        ;
+        
+        $mapper = $this->getMapper($client);
+        $mapper->findBy(new Mock\AccountMock(), array(
+            'id in' => array('0010000000xxxx1', '0010000000xxxx2')
+        ), array(), 0);
+    }
 
     protected function getClient()
     {


### PR DESCRIPTION
I added support to use an array as the findBy criteria. It will generate a parenthesis-enclosed, comma-separated list of values.

Example:

```
$mapper->findBy(new Account(), array(
  'id in' => array('0010000000xxxx1', '0010000000xxxx2')
))
```

will result in SOQL:

```
select Id, Name from Account where Id in ('0010000000xxxx1', '0010000000xxxx2')
```
